### PR TITLE
chore(docker): specify sandbox api version in docker

### DIFF
--- a/docker/werewolves-assistant-sandbox-api/docker-compose.yml
+++ b/docker/werewolves-assistant-sandbox-api/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   api:
-    image: antoinezanardi/werewolves-assistant-api:latest
+    image: antoinezanardi/werewolves-assistant-api:v1.32.4
     container_name: werewolves-assistant-api
     depends_on:
       - mongodb


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Docker image version for the `werewolves-assistant-api` service to `v1.32.4` for improved stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->