### PR TITLE
chore(sandbox-api): bump sandbox api version to 1-33-0

### DIFF
--- a/docker/werewolves-assistant-sandbox-api/docker-compose.yml
+++ b/docker/werewolves-assistant-sandbox-api/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   api:
-    image: antoinezanardi/werewolves-assistant-api:v1.32.4
+    image: antoinezanardi/werewolves-assistant-api:v1.33.0
     container_name: werewolves-assistant-api
     depends_on:
       - mongodb

--- a/tests/acceptance/features/game/features/role/pied-piper.feature
+++ b/tests/acceptance/features/game/features/role/pied-piper.feature
@@ -152,17 +152,7 @@ Feature: 🪈 Pied Piper role
     When the user goes to the next game event text
     Then the game's event should display the text "The Game Master will tap in the back the charmed player so he knows he is charmed."
 
-    When the user goes to the next game event text
-    Then the game's event should display the text "The first charmed person by the Pied Piper wakes up."
-    And the game's event player card should have the name "Bob"
-
-    When the user goes to the next game event text
-    Then the game's current play title should be "Charmed people meet each other"
-    And the game's phase name should be "Night 1"
-    And the game's current play should not expect any action
-
-    When the player or group skips his turn
-    And the user skips all game events
+    When the user skips all game events
     Then the game's current play title should be "Survivors vote"
 
     When the player or group skips his turn


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated `werewolves-assistant-api` image to version `v1.33.0` in the Docker setup for improved performance and stability.

- **Tests**
  - Streamlined acceptance tests for the Pied Piper role by consolidating steps to skip all game events, enhancing test clarity and efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->