### PR TITLE
feat(game-lobby): game options saved in local storage

### DIFF
--- a/app/utils/enums/local-storage.enums.ts
+++ b/app/utils/enums/local-storage.enums.ts
@@ -1,0 +1,5 @@
+enum LocalStorageKeys {
+  GAME_OPTIONS = "gameOptions",
+}
+
+export { LocalStorageKeys };

--- a/tests/acceptance/features/game-lobby/features/game-lobby-options-hub/game-lobby-options-hub.feature
+++ b/tests/acceptance/features/game-lobby/features/game-lobby-options-hub/game-lobby-options-hub.feature
@@ -21,6 +21,15 @@ Feature: ⚙️ Game Lobby Options Hub
     And the heading with name "Votes can be skipped" should be visible
     Then the page creates the missing snapshot with name "Game Lobby Options Hub on Votes tab"
 
+  Scenario: ⚙️ Options Hub stores changed game options in local storages and keeps the state when user comes back
+    Given the user is on game-lobby page
+    And the user disables the sheriff in game options
+    And the user reloads the page
+
+    When the user clicks on the game options button in the lobby
+    Then the heading with name "Game options" should be visible
+    And the exact text "The game will not have a Sheriff." should be visible
+
   Scenario: ⚙️ User closes the options hub with escape, close button or outside click
     Given the user is on game-lobby page
 

--- a/tests/acceptance/features/playwright/step-definitions/pages/playwright-pages.when-steps.ts
+++ b/tests/acceptance/features/playwright/step-definitions/pages/playwright-pages.when-steps.ts
@@ -5,3 +5,7 @@ import type { CustomWorld } from "@tests/acceptance/shared/types/word.types";
 When(/^the user clicks on the top left corner of the screen$/u, async function(this: CustomWorld): Promise<void> {
   await this.page.mouse.click(0, 0);
 });
+
+When(/^the user reloads the page$/u, async function(this: CustomWorld): Promise<void> {
+  await this.page.reload();
+});

--- a/tests/acceptance/features/playwright/step-definitions/texts/playwright-texts.then-steps.ts
+++ b/tests/acceptance/features/playwright/step-definitions/texts/playwright-texts.then-steps.ts
@@ -11,3 +11,7 @@ Then(/^the text "(?<text>.+?)" under the (?<role>button|img|heading|navigation|l
 Then(/^the text "(?<text>.+?)" under the (?<role>button|img|heading|navigation|link|region|alertdialog) with name "(?<name>.+)" should be hidden$/u, async function(this: CustomWorld, text: string, role: LocatorRole, name: string): Promise<void> {
   await expect(this.page.getByRole(role, { name }).getByText(text, { exact: true })).toBeHidden();
 });
+
+Then(/^the exact text "(?<text>.+?)" should be visible$/u, async function(this: CustomWorld, text: string): Promise<void> {
+  await expect(this.page.getByText(text, { exact: true })).toBeVisible();
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced local storage functionality for game options, allowing persistence across sessions.
	- Added a centralized enumeration for managing local storage keys.

- **Bug Fixes**
	- Enhanced the Game Lobby Options Hub to ensure user preferences are retained after page reloads.

- **Tests**
	- Expanded test coverage for local storage interactions in the game options store.
	- Added new step definitions for verifying text visibility and handling page reloads in Playwright tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->