### PR TITLE
feat(game-options): remove additional cards count in game options

### DIFF
--- a/app/components/pages/game-lobby/GameLobbyFooter/GameLobbyStartGameButton/GameLobbyStartGameButton.vue
+++ b/app/components/pages/game-lobby/GameLobbyFooter/GameLobbyStartGameButton/GameLobbyStartGameButton.vue
@@ -39,7 +39,6 @@ import { storeToRefs } from "pinia";
 import type { GameLobbyStartGameButtonEmits } from "~/components/pages/game-lobby/GameLobbyFooter/GameLobbyStartGameButton/game-lobby-start-game-button.types";
 import type { GameLobbyStartGameConfirmDialogExposed } from "~/components/pages/game-lobby/GameLobbyFooter/GameLobbyStartGameButton/GameLobbyStartGameConfirmDialog/game-lobby-start-game-confirm-dialog.types";
 import GameLobbyStartGameConfirmDialog from "~/components/pages/game-lobby/GameLobbyFooter/GameLobbyStartGameButton/GameLobbyStartGameConfirmDialog/GameLobbyStartGameConfirmDialog.vue";
-import { GAME_ADDITIONAL_CARDS_RECIPIENTS } from "~/composables/api/game/constants/game-additional-card/game-additional-card.constants";
 
 import { useCreateGameDtoValidation } from "~/composables/api/game/useCreateGameDtoValidation";
 import { useFetchGames } from "~/composables/api/game/useFetchGames";
@@ -57,7 +56,6 @@ const { addSuccessToast } = usePrimeVueToasts();
 const { createGame } = useFetchGames();
 
 const createGameDtoStore = useCreateGameDtoStore();
-const { getAdditionalCardsForRecipientInCreateGameDto } = createGameDtoStore;
 const { createGameDto } = storeToRefs(createGameDtoStore);
 const { canCreateGame, gameCreationValidationErrors } = useCreateGameDtoValidation(createGameDto);
 
@@ -74,18 +72,8 @@ function onClickFromStartGameButton(): void {
   gameLobbyStartGameConfirmDialog.value.open();
 }
 
-function adjustCreateGameDtoAdditionalCardsOptions(): void {
-  for (const recipient of GAME_ADDITIONAL_CARDS_RECIPIENTS) {
-    const additionalCards = getAdditionalCardsForRecipientInCreateGameDto(recipient);
-    if (additionalCards.length !== 0) {
-      createGameDto.value.options.roles[recipient].additionalCardsCount = additionalCards.length;
-    }
-  }
-}
-
 async function onConfirmStartGameFromGameLobbyStartGameConfirmDialog(): Promise<void> {
   isLoadingCreateGame.value = true;
-  adjustCreateGameDtoAdditionalCardsOptions();
   const createdGame = await createGame(createGameDto.value);
   if (createdGame) {
     await navigateTo(`/game/${createdGame._id}`);

--- a/app/components/pages/game/GamePlaying/GameEventsMonitor/GameEventsMonitorCurrentEvent/GameTurnStartsEvent/GameThiefTurnStartsEvent/GameThiefTurnStartsEvent.vue
+++ b/app/components/pages/game/GamePlaying/GameEventsMonitor/GameEventsMonitorCurrentEvent/GameTurnStartsEvent/GameThiefTurnStartsEvent/GameThiefTurnStartsEvent.vue
@@ -22,7 +22,7 @@ const { playSoundEffect } = audioStore;
 
 const { t } = useI18n();
 
-const thiefAdditionalCardsCount = computed<number>(() => game.value.options.roles.thief.additionalCardsCount);
+const thiefAdditionalCardsCount = computed<number>(() => game.value.additionalCards.filter(card => card.recipient === "thief").length);
 
 const mustThiefChooseBetweenWerewolves = computed<boolean>(() => game.value.options.roles.thief.mustChooseBetweenWerewolves);
 

--- a/app/composables/api/game/constants/game-options/game-options.constants.ts
+++ b/app/composables/api/game/constants/game-options/game-options.constants.ts
@@ -49,7 +49,6 @@ const DEFAULT_GAME_OPTIONS: GameOptions = {
     thief: {
       mustChooseBetweenWerewolves: true,
       isChosenCardRevealed: false,
-      additionalCardsCount: 2,
     },
     piedPiper: {
       charmedPeopleCountPerNight: 2,
@@ -61,7 +60,6 @@ const DEFAULT_GAME_OPTIONS: GameOptions = {
     prejudicedManipulator: { isPowerlessOnWerewolvesSide: true },
     actor: {
       isPowerlessOnWerewolvesSide: true,
-      additionalCardsCount: 3,
     },
   },
 } as const;

--- a/app/composables/api/game/game-options/useGameOptionsTexts.ts
+++ b/app/composables/api/game/game-options/useGameOptionsTexts.ts
@@ -83,7 +83,6 @@ function useGameOptionsTexts(gameOptions: Ref<GameOptions>): UseGameOptionsTexts
       thief: {
         mustChooseBetweenWerewolves: t(`composables.useGameOptionsTexts.roles.thief.mustChooseBetweenWerewolves.${convertBooleanAsAffirmativeString(gameOptions.value.roles.thief.mustChooseBetweenWerewolves)}`),
         isChosenCardRevealed: t(`composables.useGameOptionsTexts.roles.thief.isChosenCardRevealed.${convertBooleanAsAffirmativeString(gameOptions.value.roles.thief.isChosenCardRevealed)}`),
-        additionalCardsCount: "",
       },
       piedPiper: {
         charmedPeopleCountPerNight: t(`composables.useGameOptionsTexts.roles.piedPiper.charmedPeopleCountPerNight`, { charmedPeopleCountPerNight: gameOptions.value.roles.piedPiper.charmedPeopleCountPerNight }, gameOptions.value.roles.piedPiper.charmedPeopleCountPerNight),
@@ -95,7 +94,6 @@ function useGameOptionsTexts(gameOptions: Ref<GameOptions>): UseGameOptionsTexts
       prejudicedManipulator: { isPowerlessOnWerewolvesSide: t(`composables.useGameOptionsTexts.roles.prejudicedManipulator.isPowerlessOnWerewolvesSide.${convertBooleanAsAffirmativeString(gameOptions.value.roles.prejudicedManipulator.isPowerlessOnWerewolvesSide)}`) },
       actor: {
         isPowerlessOnWerewolvesSide: t(`composables.useGameOptionsTexts.roles.actor.isPowerlessOnWerewolvesSide.${convertBooleanAsAffirmativeString(gameOptions.value.roles.actor.isPowerlessOnWerewolvesSide)}`),
-        additionalCardsCount: "",
       },
     },
   }));

--- a/app/composables/api/game/types/game-options/roles-game-options/actor-game-options/actor-game-options.class.ts
+++ b/app/composables/api/game/types/game-options/roles-game-options/actor-game-options/actor-game-options.class.ts
@@ -5,9 +5,6 @@ class ActorGameOptions {
   @Expose()
   public isPowerlessOnWerewolvesSide: boolean;
 
-  @Expose()
-  public additionalCardsCount: number;
-
   public static create(actorGameOptions: ActorGameOptions): ActorGameOptions {
     return plainToInstance(ActorGameOptions, actorGameOptions, DEFAULT_PLAIN_TO_INSTANCE_OPTIONS);
   }

--- a/app/composables/api/game/types/game-options/roles-game-options/thief-game-options/thief-game-options.class.ts
+++ b/app/composables/api/game/types/game-options/roles-game-options/thief-game-options/thief-game-options.class.ts
@@ -8,9 +8,6 @@ class ThiefGameOptions {
   @Expose()
   public isChosenCardRevealed: boolean;
 
-  @Expose()
-  public additionalCardsCount: number;
-
   public static create(thiefGameOptions: ThiefGameOptions): ThiefGameOptions {
     return plainToInstance(ThiefGameOptions, thiefGameOptions, DEFAULT_PLAIN_TO_INSTANCE_OPTIONS);
   }

--- a/docker/werewolves-assistant-sandbox-api/docker-compose.yml
+++ b/docker/werewolves-assistant-sandbox-api/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   api:
-    image: antoinezanardi/werewolves-assistant-api:v1.35.2
+    image: antoinezanardi/werewolves-assistant-api:v1.36.0
     container_name: werewolves-assistant-sandbox-api
     depends_on:
       - mongodb

--- a/tests/acceptance/features/game/features/role/thief.feature
+++ b/tests/acceptance/features/game/features/role/thief.feature
@@ -98,7 +98,7 @@ Feature: 👺 Thief role
     And the user closes the toast
     And the user goes to the next game event text
     And the user goes to the next game event text
-    Then the game's event should display the text "This game is special with 3 changed options. Let's see how it goes…"
+    Then the game's event should display the text "This game is special with 2 changed options. Let's see how it goes…"
 
     When the user goes to the next game event text
     Then the game's event should display the text "Special rule 1 : The game will not have a Sheriff."

--- a/tests/unit/specs/components/pages/game-lobby/GameLobbyFooter/GameLobbyStartGameButton/GameLobbyStartGameButton.nuxt.spec.ts
+++ b/tests/unit/specs/components/pages/game-lobby/GameLobbyFooter/GameLobbyStartGameButton/GameLobbyStartGameButton.nuxt.spec.ts
@@ -1,23 +1,4 @@
 import { createTestingPinia } from "@pinia/testing";
-import { createFakeCreateGameAdditionalCardDto } from "@tests/unit/utils/factories/composables/api/game/dto/create-game/create-game-additional-card/create-game-additional-card.dto.factory";
-import { getError } from "@tests/unit/utils/helpers/exception.helpers";
-import type { VueVm } from "@tests/unit/utils/types/vue-test-utils.types";
-import type { mount } from "@vue/test-utils";
-import { flushPromises } from "@vue/test-utils";
-import type { ComponentMountingOptions } from "@vue/test-utils/dist/mount";
-import type Button from "primevue/button";
-import { expect } from "vitest";
-import type { Mock } from "vitest";
-import type { Ref } from "vue";
-
-import GameLobbyStartGameButton from "~/components/pages/game-lobby/GameLobbyFooter/GameLobbyStartGameButton/GameLobbyStartGameButton.vue";
-import type GameLobbyStartGameConfirmDialog from "~/components/pages/game-lobby/GameLobbyFooter/GameLobbyStartGameButton/GameLobbyStartGameConfirmDialog/GameLobbyStartGameConfirmDialog.vue";
-import { DEFAULT_GAME_OPTIONS } from "~/composables/api/game/constants/game-options/game-options.constants";
-import type { CreateGameDto } from "~/composables/api/game/dto/create-game/create-game.dto";
-import * as UseFetchGames from "~/composables/api/game/useFetchGames";
-import * as UsePrimeVueToasts from "~/composables/prime-vue/usePrimeVueToasts";
-import { useCreateGameDtoStore } from "~/stores/game/create-game-dto/useCreateGameDtoStore";
-import { useRolesStore } from "~/stores/role/useRolesStore";
 import { createFakeCreateGamePlayerDto } from "@tests/unit/utils/factories/composables/api/game/dto/create-game/create-game-player/create-game-player.dto.factory";
 import { createFakeCreateGameDto } from "@tests/unit/utils/factories/composables/api/game/dto/create-game/create-game.dto.factory";
 import { createFakeGame } from "@tests/unit/utils/factories/composables/api/game/game.factory";
@@ -25,8 +6,24 @@ import { createFakeUseFetchGames } from "@tests/unit/utils/factories/composables
 import { createFakeRole } from "@tests/unit/utils/factories/composables/api/role/role.factory";
 import { createFakeUsePrimeVueToasts } from "@tests/unit/utils/factories/composables/prime-vue/usePrimeVueToasts.factory";
 import { pTooltipDirectiveBinder } from "@tests/unit/utils/helpers/directive.helpers";
+import { getError } from "@tests/unit/utils/helpers/exception.helpers";
 import { mountSuspendedComponent } from "@tests/unit/utils/helpers/mount.helpers";
 import type { BoundTooltip } from "@tests/unit/utils/types/directive.types";
+import type { VueVm } from "@tests/unit/utils/types/vue-test-utils.types";
+import type { mount } from "@vue/test-utils";
+import { flushPromises } from "@vue/test-utils";
+import type { ComponentMountingOptions } from "@vue/test-utils/dist/mount";
+import type Button from "primevue/button";
+import type { Mock } from "vitest";
+import { expect } from "vitest";
+import type { Ref } from "vue";
+
+import GameLobbyStartGameButton from "~/components/pages/game-lobby/GameLobbyFooter/GameLobbyStartGameButton/GameLobbyStartGameButton.vue";
+import type GameLobbyStartGameConfirmDialog from "~/components/pages/game-lobby/GameLobbyFooter/GameLobbyStartGameButton/GameLobbyStartGameConfirmDialog/GameLobbyStartGameConfirmDialog.vue";
+import * as UseFetchGames from "~/composables/api/game/useFetchGames";
+import * as UsePrimeVueToasts from "~/composables/prime-vue/usePrimeVueToasts";
+import { useCreateGameDtoStore } from "~/stores/game/create-game-dto/useCreateGameDtoStore";
+import { useRolesStore } from "~/stores/role/useRolesStore";
 
 describe("Game Lobby Start Game Button Component", () => {
   const validCreateGameDto = createFakeCreateGameDto({
@@ -213,28 +210,6 @@ describe("Game Lobby Start Game Button Component", () => {
             createFakeCreateGamePlayerDto({ name: "Player 4" }),
           ],
         });
-      });
-
-      it("should adjust game additional cards count in create game dto options when confirm start game event is emitted.", async() => {
-        const initialCreateGameDto = createFakeCreateGameDto({
-          additionalCards: [
-            createFakeCreateGameAdditionalCardDto({
-              recipient: "thief",
-              roleName: "werewolf",
-            }),
-          ],
-          options: DEFAULT_GAME_OPTIONS,
-        });
-        const createGameDtoStore = useCreateGameDtoStore();
-        createGameDtoStore.createGameDto = createFakeCreateGameDto(initialCreateGameDto);
-        const expectedCreateGameDto = createFakeCreateGameDto(initialCreateGameDto);
-        expectedCreateGameDto.options.roles.thief.additionalCardsCount = 1;
-        expectedCreateGameDto.options.roles.actor.additionalCardsCount = 3;
-        const gameLobbyStartGameConfirmDialog = wrapper.findComponent<typeof GameLobbyStartGameConfirmDialog>("#game-lobby-start-game-confirm-dialog");
-        (gameLobbyStartGameConfirmDialog.vm as VueVm).$emit("confirm-start-game");
-        await nextTick();
-
-        expect(createGameDtoStore.createGameDto).toStrictEqual<CreateGameDto>(expectedCreateGameDto);
       });
 
       it("should create game when confirm start game event is emitted.", async() => {

--- a/tests/unit/specs/components/pages/game/GamePlaying/GameEventsMonitor/GameEventsMonitorCurrentEvent/GameTurnStartsEvent/GameThiefTurnStartsEvent/GameThiefTurnStartsEvent.nuxt.spec.ts
+++ b/tests/unit/specs/components/pages/game/GamePlaying/GameEventsMonitor/GameEventsMonitorCurrentEvent/GameTurnStartsEvent/GameThiefTurnStartsEvent/GameThiefTurnStartsEvent.nuxt.spec.ts
@@ -1,4 +1,5 @@
 import { createTestingPinia } from "@pinia/testing";
+import { createFakeGameAdditionalCard } from "@tests/unit/utils/factories/composables/api/game/game-additional-card/game-additional-card.factory";
 import type { mount } from "@vue/test-utils";
 import type { ComponentMountingOptions } from "@vue/test-utils/dist/mount";
 import GameThiefTurnStartsEvent from "~/components/pages/game/GamePlaying/GameEventsMonitor/GameEventsMonitorCurrentEvent/GameTurnStartsEvent/GameThiefTurnStartsEvent/GameThiefTurnStartsEvent.vue";
@@ -12,7 +13,23 @@ import { useGameStore } from "~/stores/game/useGameStore";
 
 describe("Game Thief Turn Starts Event Component", () => {
   let wrapper: ReturnType<typeof mount<typeof GameThiefTurnStartsEvent>>;
-  const defaultGame = createFakeGame({ options: DEFAULT_GAME_OPTIONS });
+  const defaultGame = createFakeGame({
+    additionalCards: [
+      createFakeGameAdditionalCard({
+        recipient: "thief",
+        roleName: "werewolf",
+      }),
+      createFakeGameAdditionalCard({
+        recipient: "thief",
+        roleName: "villager",
+      }),
+      createFakeGameAdditionalCard({
+        recipient: "actor",
+        roleName: "werewolf",
+      }),
+    ],
+    options: DEFAULT_GAME_OPTIONS,
+  });
   const testingPinia = { initialState: { [StoreIds.GAME]: { game: defaultGame } } };
 
   async function mountGameThiefTurnStartsEventComponent(options: ComponentMountingOptions<typeof GameThiefTurnStartsEvent> = {}):

--- a/tests/unit/specs/composables/api/game/game-options/roles-game-options/actor-game-options/actor-game-options.class.spec.ts
+++ b/tests/unit/specs/composables/api/game/game-options/roles-game-options/actor-game-options/actor-game-options.class.spec.ts
@@ -4,11 +4,9 @@ describe("Actor Game Options Class", () => {
   describe("create", () => {
     it("should create an actor game options when called.", () => {
       const createdActorGameOptions = ActorGameOptions.create({
-        additionalCardsCount: 1,
         isPowerlessOnWerewolvesSide: false,
       });
       const expectedActorGameOptions = new ActorGameOptions();
-      expectedActorGameOptions.additionalCardsCount = 1;
       expectedActorGameOptions.isPowerlessOnWerewolvesSide = false;
 
       expect(createdActorGameOptions).toStrictEqual<ActorGameOptions>(expectedActorGameOptions);

--- a/tests/unit/specs/composables/api/game/game-options/roles-game-options/thief-game-options/thief-game-options.class.spec.ts
+++ b/tests/unit/specs/composables/api/game/game-options/roles-game-options/thief-game-options/thief-game-options.class.spec.ts
@@ -6,12 +6,10 @@ describe("Thief Game Options Class", () => {
       const createdThiefGameOptions = ThiefGameOptions.create({
         mustChooseBetweenWerewolves: false,
         isChosenCardRevealed: false,
-        additionalCardsCount: 4,
       });
       const expectedThiefGameOptions = new ThiefGameOptions();
       expectedThiefGameOptions.mustChooseBetweenWerewolves = false;
       expectedThiefGameOptions.isChosenCardRevealed = false;
-      expectedThiefGameOptions.additionalCardsCount = 4;
 
       expect(createdThiefGameOptions).toStrictEqual<ThiefGameOptions>(expectedThiefGameOptions);
     });

--- a/tests/unit/specs/composables/api/game/game-options/useGameOptionsTexts.spec.ts
+++ b/tests/unit/specs/composables/api/game/game-options/useGameOptionsTexts.spec.ts
@@ -57,7 +57,6 @@ describe("Use Game Options Texts Composable", () => {
           thief: {
             mustChooseBetweenWerewolves: `composables.useGameOptionsTexts.roles.thief.mustChooseBetweenWerewolves.yes`,
             isChosenCardRevealed: `composables.useGameOptionsTexts.roles.thief.isChosenCardRevealed.no`,
-            additionalCardsCount: "",
           },
           piedPiper: {
             charmedPeopleCountPerNight: `composables.useGameOptionsTexts.roles.piedPiper.charmedPeopleCountPerNight, {"charmedPeopleCountPerNight":2}, 2`,
@@ -69,7 +68,6 @@ describe("Use Game Options Texts Composable", () => {
           prejudicedManipulator: { isPowerlessOnWerewolvesSide: `composables.useGameOptionsTexts.roles.prejudicedManipulator.isPowerlessOnWerewolvesSide.yes` },
           actor: {
             isPowerlessOnWerewolvesSide: `composables.useGameOptionsTexts.roles.actor.isPowerlessOnWerewolvesSide.yes`,
-            additionalCardsCount: "",
           },
         },
       };

--- a/tests/unit/utils/factories/composables/api/game/game-options/roles-game-options/actor-game-options/actor-game-options.factory.ts
+++ b/tests/unit/utils/factories/composables/api/game/game-options/roles-game-options/actor-game-options/actor-game-options.factory.ts
@@ -3,7 +3,6 @@ import { ActorGameOptions } from "~/composables/api/game/types/game-options/role
 
 function createFakeActorGameOptionsFactory(actorGameOptionsFactory: Partial<ActorGameOptions> = {}): ActorGameOptions {
   return ActorGameOptions.create({
-    additionalCardsCount: actorGameOptionsFactory.additionalCardsCount ?? faker.number.int({ min: 1, max: 5 }),
     isPowerlessOnWerewolvesSide: actorGameOptionsFactory.isPowerlessOnWerewolvesSide ?? faker.datatype.boolean(),
   });
 }

--- a/tests/unit/utils/factories/composables/api/game/game-options/roles-game-options/thief-game-options/thief-game-options.factory.ts
+++ b/tests/unit/utils/factories/composables/api/game/game-options/roles-game-options/thief-game-options/thief-game-options.factory.ts
@@ -3,7 +3,6 @@ import { ThiefGameOptions } from "~/composables/api/game/types/game-options/role
 
 function createFakeThiefGameOptions(thiefGameOptions: Partial<ThiefGameOptions> = {}): ThiefGameOptions {
   return ThiefGameOptions.create({
-    additionalCardsCount: thiefGameOptions.additionalCardsCount ?? faker.number.int({ min: 1, max: 5 }),
     isChosenCardRevealed: thiefGameOptions.isChosenCardRevealed ?? faker.datatype.boolean(),
     mustChooseBetweenWerewolves: thiefGameOptions.mustChooseBetweenWerewolves ?? faker.datatype.boolean(),
   });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced accuracy in calculating the thief's additional cards based on the current game state.
	- Simplified game creation process by removing unnecessary adjustments to additional card options.

- **Bug Fixes**
	- Updated game event assertions to reflect the correct number of changed options.

- **Chores**
	- Upgraded API service version for potential improvements and bug fixes.

- **Tests**
	- Adjusted tests to align with the removal of `additionalCardsCount` from game options, ensuring they reflect the current game mechanics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->