### PR TITLE
feat(game-lobby): reset game options button

### DIFF
--- a/app/components/pages/game-lobby/GameLobbyOptionsHub/GameLobbyOptionsHub.vue
+++ b/app/components/pages/game-lobby/GameLobbyOptionsHub/GameLobbyOptionsHub.vue
@@ -29,8 +29,8 @@
     </template>
 
     <template #footer>
-      <DialogFooterCloseButtonOnly
-        id="close-button-only-dialog-footer"
+      <GameLobbyOptionsHubFooter
+        id="game-lobby-options-hub-footer"
         @close-dialog="close"
       />
     </template>
@@ -38,8 +38,8 @@
 </template>
 
 <script setup lang="ts">
+import GameLobbyOptionsHubFooter from "~/components/pages/game-lobby/GameLobbyOptionsHub/GameLobbyOptionsHubFooter/GameLobbyOptionsHubFooter.vue";
 import GameLobbyOptionsHubContent from "~/components/pages/game-lobby/GameLobbyOptionsHub/GameLobbyOptionsHubTabView/GameLobbyOptionsHubTabView.vue";
-import DialogFooterCloseButtonOnly from "~/components/shared/dialogs/DialogFooterCloseButtonOnly/DialogFooterCloseButtonOnly.vue";
 import DialogHeaderTitleOnly from "~/components/shared/dialogs/DialogHeaderTitleOnly/DialogHeaderTitleOnly.vue";
 
 const isVisible = ref<boolean>(false);

--- a/app/components/pages/game-lobby/GameLobbyOptionsHub/GameLobbyOptionsHubFooter/GameLobbyOptionsHubFooter.vue
+++ b/app/components/pages/game-lobby/GameLobbyOptionsHub/GameLobbyOptionsHubFooter/GameLobbyOptionsHubFooter.vue
@@ -1,0 +1,66 @@
+<template>
+  <div
+    id="close-button-only-dialog-footer"
+    class="w-full"
+  >
+    <PrimeVueDivider class="!my-2"/>
+
+    <div class="flex justify-between w-full">
+      <Transition
+        mode="out-in"
+        name="fade"
+      >
+        <PrimeVueButton
+          v-if="isResetOptionsButtonDisplayed"
+          id="reset-options-button"
+          v-p-tooltip.top="$t('components.GameLobbyOptionsHubFooter.youHaveChangedOptions', { 'count': changedGameOptionsTexts.length })"
+          :label="$t('components.GameLobbyOptionsHubFooter.resetOptions')"
+          severity="primary"
+          @click.prevent="resetGameOptions"
+        >
+          <template #icon>
+            <FontAwesomeIcon
+              id="icon"
+              icon="rotate"
+            />
+          </template>
+        </PrimeVueButton>
+
+        <div v-else/>
+      </Transition>
+
+      <PrimeVueButton
+        id="close-button"
+        :label="$t('shared.actions.close')"
+        severity="secondary"
+        @click.prevent="close"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { storeToRefs } from "pinia";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import type { GameLobbyOptionsHubFooterEmits } from "~/components/pages/game-lobby/GameLobbyOptionsHub/GameLobbyOptionsHubFooter/game-lobby-options-hub-footer.types";
+import { useGameOptionsTexts } from "~/composables/api/game/game-options/useGameOptionsTexts";
+import { useCreateGameDtoStore } from "~/stores/game/create-game-dto/useCreateGameDtoStore";
+
+const emit = defineEmits<GameLobbyOptionsHubFooterEmits>();
+
+const createGameDtoStore = useCreateGameDtoStore();
+const { resetCreateGameOptionsDto } = createGameDtoStore;
+const { createGameOptionsDto } = storeToRefs(createGameDtoStore);
+
+const { changedGameOptionsTexts } = useGameOptionsTexts(createGameOptionsDto);
+
+const isResetOptionsButtonDisplayed = computed<boolean>(() => changedGameOptionsTexts.value.length > 0);
+
+function resetGameOptions(): void {
+  resetCreateGameOptionsDto();
+}
+
+function close(): void {
+  emit("closeDialog");
+}
+</script>

--- a/app/components/pages/game-lobby/GameLobbyOptionsHub/GameLobbyOptionsHubFooter/game-lobby-options-hub-footer.types.ts
+++ b/app/components/pages/game-lobby/GameLobbyOptionsHub/GameLobbyOptionsHubFooter/game-lobby-options-hub-footer.types.ts
@@ -1,0 +1,5 @@
+type GameLobbyOptionsHubFooterEmits = {
+  closeDialog: [];
+};
+
+export type { GameLobbyOptionsHubFooterEmits };

--- a/app/components/shared/dialogs/DialogFooterCloseButtonOnly/DialogFooterCloseButtonOnly.vue
+++ b/app/components/shared/dialogs/DialogFooterCloseButtonOnly/DialogFooterCloseButtonOnly.vue
@@ -7,7 +7,7 @@
 
     <div class="flex justify-end w-full">
       <PrimeVueButton
-        id="close-button-only-dialog-footer-close-button"
+        id="only-dialog-footer-close-button"
         :label="$t('shared.actions.close')"
         severity="secondary"
         size="small"

--- a/app/plugins/vue-font-awesome-icon/vue-font-awesome-icon.ts
+++ b/app/plugins/vue-font-awesome-icon/vue-font-awesome-icon.ts
@@ -74,6 +74,7 @@ import {
   faHandHoldingHeart,
   faCloudMoon,
   faCompass,
+  faRotate,
 } from "@fortawesome/free-solid-svg-icons";
 
 import { faQuestionCircle } from "@fortawesome/free-regular-svg-icons";
@@ -158,6 +159,7 @@ library.add(
   faHandHoldingHeart,
   faCloudMoon,
   faCompass,
+  faRotate,
 );
 
 export default defineNuxtPlugin(nuxtApp => {

--- a/app/stores/game/create-game-dto/useCreateGameDtoStore.ts
+++ b/app/stores/game/create-game-dto/useCreateGameDtoStore.ts
@@ -6,7 +6,7 @@ import type { CreateGameAdditionalCardDto } from "~/composables/api/game/dto/cre
 import { CreateGamePlayerDto } from "~/composables/api/game/dto/create-game/create-game-player/create-game-player.dto";
 import { CreateGameDto } from "~/composables/api/game/dto/create-game/create-game.dto";
 import type { GameAdditionalCardRecipientRoleName } from "~/composables/api/game/types/game-additional-card/game-additional-card.types";
-import type { GameOptions } from "~/composables/api/game/types/game-options/game-options.class";
+import { GameOptions } from "~/composables/api/game/types/game-options/game-options.class";
 import { ADDITIONAL_CARDS_DEPENDANT_ROLES } from "~/composables/api/role/constants/role.constants";
 import type { RoleName } from "~/composables/api/role/types/role.types";
 import { StoreIds } from "~/stores/enums/store.enum";
@@ -61,6 +61,11 @@ const useCreateGameDtoStore = defineStore(StoreIds.CREATE_GAME_DTO, () => {
       ...defaultCreateGameDto,
       options: createGameOptionsDtoFromLocalStorage.value,
     });
+  }
+
+  function resetCreateGameOptionsDto(): void {
+    createGameDto.value.options = GameOptions.create(DEFAULT_GAME_OPTIONS);
+    saveCreateGameOptionsDtoToLocalStorage();
   }
 
   function saveCreateGameOptionsDtoToLocalStorage(): void {
@@ -158,6 +163,7 @@ const useCreateGameDtoStore = defineStore(StoreIds.CREATE_GAME_DTO, () => {
     doesCreateGameDtoContainAdditionalCardsDependantRoles,
     setCreateGameDto,
     resetCreateGameDto,
+    resetCreateGameOptionsDto,
     saveCreateGameOptionsDtoToLocalStorage,
     removeObsoleteAdditionalCardsFromCreateGameDto,
     addPlayerToCreateGameDto,

--- a/modules/i18n/locales/en.json
+++ b/modules/i18n/locales/en.json
@@ -1592,6 +1592,10 @@
       "actorAdditionalCardsMustBePlacedUp": "Is the additional card for the Actor placed face up on the center of the table? | Are the additional cards for the Actor placed face up on the center of the table?",
       "changeActorAdditionalCards": "Change the additional cards for the Actor",
       "actorIcon": "Actor icon"
+    },
+    "GameLobbyOptionsHubFooter": {
+      "resetOptions": "Restore official rules",
+      "youHaveChangedOptions": "You have changed one option | You have changed {count} options"
     }
   }
 }

--- a/modules/i18n/locales/fr.json
+++ b/modules/i18n/locales/fr.json
@@ -1592,6 +1592,10 @@
       "actorAdditionalCardsMustBePlacedUp": "La carte destinée au Comédien est-elle placée face visible au centre de la table ? | Les cartes destinées au Comédien sont-elles placées face visible au centre de la table ?",
       "changeActorAdditionalCards": "Changer les cartes destinée au Comédien",
       "actorIcon": "Icône du Comédien"
+    },
+    "GameLobbyOptionsHubFooter": {
+      "resetOptions": "Revenir aux règles officielles",
+      "youHaveChangedOptions": "Vous avez appliqué 1 variante de règles | Vous avez appliqué {count} variantes de règles"
     }
   }
 }

--- a/tests/acceptance/features/game-lobby/features/game-lobby-options-hub/game-lobby-options-hub.feature
+++ b/tests/acceptance/features/game-lobby/features/game-lobby-options-hub/game-lobby-options-hub.feature
@@ -30,6 +30,16 @@ Feature: ⚙️ Game Lobby Options Hub
     Then the heading with name "Game options" should be visible
     And the exact text "The game will not have a Sheriff." should be visible
 
+  Scenario: ⚙️ User can restore official rules by clicking on reset button
+    Given the user is on game-lobby page
+    And the user disables the sheriff in game options
+    And the user clicks on the game options button in the lobby
+    Then the heading with name "Game options" should be visible
+    And the exact text "The game will not have a Sheriff." should be visible
+
+    When the user clicks on the button with name "Restore official rules"
+    Then the exact text "The game will have a Sheriff." should be visible
+
   Scenario: ⚙️ User closes the options hub with escape, close button or outside click
     Given the user is on game-lobby page
 
@@ -41,10 +51,6 @@ Feature: ⚙️ Game Lobby Options Hub
 
     When the user clicks on the game options button in the lobby
     And the user clicks on the close button of the dialog's header
-    Then the heading with exact name "Game options" should be hidden
-
-    When the user clicks on the game options button in the lobby
-    And the user clicks on the close button of the dialog's footer
     Then the heading with exact name "Game options" should be hidden
 
     When the user clicks on the game options button in the lobby

--- a/tests/unit/specs/components/pages/game-lobby/GameLobbyOptionsHub/GameLobbyOptionsHub.nuxt.spec.ts
+++ b/tests/unit/specs/components/pages/game-lobby/GameLobbyOptionsHub/GameLobbyOptionsHub.nuxt.spec.ts
@@ -3,9 +3,9 @@ import type { ComponentMountingOptions } from "@vue/test-utils/dist/mount";
 import Dialog, { type DialogProps } from "primevue/dialog";
 import type { GameLobbyOptionsHubExposed } from "~/components/pages/game-lobby/GameLobbyOptionsHub/game-lobby-options-hub.types";
 import GameLobbyOptionsHub from "~/components/pages/game-lobby/GameLobbyOptionsHub/GameLobbyOptionsHub.vue";
+import type GameLobbyOptionsHubFooter from "~/components/pages/game-lobby/GameLobbyOptionsHub/GameLobbyOptionsHubFooter/GameLobbyOptionsHubFooter.vue";
 import type GameLobbyOptionsHubHeader from "~/components/pages/game-lobby/GameLobbyOptionsHub/GameLobbyOptionsHubHeader/GameLobbyOptionsHubHeader.vue";
 import type GameLobbyOptionsHubContent from "~/components/pages/game-lobby/GameLobbyOptionsHub/GameLobbyOptionsHubContent/GameLobbyOptionsHubContent.vue";
-import type DialogFooterCloseButtonOnly from "~/components/shared/dialogs/DialogFooterCloseButtonOnly/DialogFooterCloseButtonOnly.vue";
 
 import { mountSuspendedComponent } from "@tests/unit/utils/helpers/mount.helpers";
 import type { VueVm } from "@tests/unit/utils/types/vue-test-utils.types";
@@ -21,7 +21,7 @@ describe("Game Lobby Options Hub Component", () => {
         stubs: {
           GameLobbyOptionsHubHeader: true,
           GameLobbyOptionsHubContent: true,
-          DialogFooterCloseButtonOnly: true,
+          GameLobbyOptionsHubFooter: true,
         },
       },
       ...options,
@@ -64,7 +64,7 @@ describe("Game Lobby Options Hub Component", () => {
 
     describe("Game Lobby Options Hub Footer", () => {
       it("should not render game lobby options hub footer when dialog is not open.", () => {
-        const dialogFooterCloseButtonOnly = wrapper.findComponent<typeof DialogFooterCloseButtonOnly>("#close-button-only-dialog-footer");
+        const dialogFooterCloseButtonOnly = wrapper.findComponent<typeof GameLobbyOptionsHubFooter>("#game-lobby-options-hub-footer");
 
         expect(dialogFooterCloseButtonOnly.exists()).toBeFalsy();
       });
@@ -102,13 +102,13 @@ describe("Game Lobby Options Hub Component", () => {
 
     describe("Game Lobby Options Hub Footer", () => {
       it("should render game lobby options hub footer when opened.", () => {
-        const dialogFooterCloseButtonOnly = wrapper.findComponent<typeof DialogFooterCloseButtonOnly>("#close-button-only-dialog-footer");
+        const dialogFooterCloseButtonOnly = wrapper.findComponent<typeof GameLobbyOptionsHubFooter>("#game-lobby-options-hub-footer");
 
         expect(dialogFooterCloseButtonOnly.exists()).toBeTruthy();
       });
 
       it("should close options hub when option hub footer emits event.", async() => {
-        const dialogFooterCloseButtonOnly = wrapper.findComponent<typeof DialogFooterCloseButtonOnly>("#close-button-only-dialog-footer");
+        const dialogFooterCloseButtonOnly = wrapper.findComponent<typeof GameLobbyOptionsHubFooter>("#game-lobby-options-hub-footer");
         (dialogFooterCloseButtonOnly.vm as VueVm).$emit("close-dialog");
         await nextTick();
         const dialog = wrapper.findComponent<typeof Dialog>(Dialog);

--- a/tests/unit/specs/components/pages/game-lobby/GameLobbyOptionsHub/GameLobbyOptionsHubFooter/GameLobbyOptionsHubFooter.nuxt.spec.ts
+++ b/tests/unit/specs/components/pages/game-lobby/GameLobbyOptionsHub/GameLobbyOptionsHubFooter/GameLobbyOptionsHubFooter.nuxt.spec.ts
@@ -1,0 +1,107 @@
+import { createFakeCreateGameDto } from "@tests/unit/utils/factories/composables/api/game/dto/create-game/create-game.dto.factory";
+import { pTooltipDirectiveBinder } from "@tests/unit/utils/helpers/directive.helpers";
+import type { BoundTooltip } from "@tests/unit/utils/types/directive.types";
+import type { mount } from "@vue/test-utils";
+import { createTestingPinia } from "@pinia/testing";
+
+import type Button from "primevue/button";
+import { mountSuspendedComponent } from "@tests/unit/utils/helpers/mount.helpers";
+import type { ComponentMountingOptions } from "@vue/test-utils/dist/mount";
+import GameLobbyOptionsHubFooter from "~/components/pages/game-lobby/GameLobbyOptionsHub/GameLobbyOptionsHubFooter/GameLobbyOptionsHubFooter.vue";
+import { DEFAULT_GAME_OPTIONS } from "~/composables/api/game/constants/game-options/game-options.constants";
+import { StoreIds } from "~/stores/enums/store.enum";
+import { useCreateGameDtoStore } from "~/stores/game/create-game-dto/useCreateGameDtoStore";
+
+describe("Game Lobby Options Hub Footer Component", () => {
+  const defaultCreateGameDto = createFakeCreateGameDto({
+    options: DEFAULT_GAME_OPTIONS,
+  });
+  let wrapper: ReturnType<typeof mount<typeof GameLobbyOptionsHubFooter>>;
+  const testingPinia = { initialState: { [StoreIds.CREATE_GAME_DTO]: { createGameDto: defaultCreateGameDto } } };
+
+  async function mountGameLobbyOptionsHubFooterComponent(options: ComponentMountingOptions<typeof GameLobbyOptionsHubFooter> = {}):
+  Promise<ReturnType<typeof mount<typeof GameLobbyOptionsHubFooter>>> {
+    return mountSuspendedComponent(GameLobbyOptionsHubFooter, {
+      global: {
+        plugins: [createTestingPinia(testingPinia)],
+      },
+      ...options,
+    });
+  }
+
+  beforeEach(async() => {
+    wrapper = await mountGameLobbyOptionsHubFooterComponent();
+  });
+
+  it("should match snapshot when rendered.", () => {
+    expect(wrapper).toBeTruthy();
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+
+  describe("Reset Options Button", () => {
+    it("should not render reset options button when no options have been changed based on default game options.", () => {
+      const resetOptionsButton = wrapper.findComponent<typeof Button>("#reset-options-button");
+
+      expect(resetOptionsButton.exists()).toBeFalsy();
+    });
+
+    describe("Button is rendered", () => {
+      beforeEach(() => {
+        const createGameDtoStore = useCreateGameDtoStore();
+        createGameDtoStore.createGameDto.options.composition.isHidden = true;
+      });
+
+      it("should render reset options button when options have been changed.", () => {
+        const resetOptionsButton = wrapper.findComponent<typeof Button>("#reset-options-button");
+
+        expect(resetOptionsButton.exists()).toBeTruthy();
+      });
+
+      it("should translate label of reset options button when rendered.", () => {
+        const resetOptionsButton = wrapper.findComponent<typeof Button>("#reset-options-button");
+
+        expect(resetOptionsButton.attributes("label")).toBe("Restore official rules");
+      });
+
+      it("should attach tooltip to reset options button when rendered.", async() => {
+        const tooltip: BoundTooltip = { value: undefined };
+        const directives = { ...pTooltipDirectiveBinder(tooltip, `#reset-options-button`) };
+        wrapper = await mountGameLobbyOptionsHubFooterComponent({
+          global: {
+            directives,
+            plugins: [createTestingPinia(testingPinia)],
+          },
+        });
+        const createGameDtoStore = useCreateGameDtoStore();
+        createGameDtoStore.createGameDto.options.composition.isHidden = true;
+        createGameDtoStore.createGameDto.options.votes.canBeSkipped = false;
+        await nextTick();
+
+        expect(tooltip.value).toBe("You have changed 2 options");
+      });
+
+      it("should reset options when reset options button is clicked.", async() => {
+        const resetOptionsButton = wrapper.findComponent<typeof Button>("#reset-options-button");
+        await resetOptionsButton.trigger("click");
+        const createGameDtoStore = useCreateGameDtoStore();
+
+        expect(createGameDtoStore.resetCreateGameOptionsDto).toHaveBeenCalledExactlyOnceWith();
+      });
+    });
+  });
+
+  describe("Close Button", () => {
+    it("should translate close button when rendered.", () => {
+      const closeButton = wrapper.findComponent<typeof Button>("#close-button");
+
+      expect(closeButton.attributes("label")).toBe("Close");
+    });
+
+    it("should emit close event when close button is clicked.", async() => {
+      const closeButton = wrapper.findComponent<typeof Button>("#close-button");
+      await closeButton.trigger("click");
+
+      expect(wrapper.emitted("closeDialog")).toBeTruthy();
+    });
+  });
+});

--- a/tests/unit/specs/components/pages/game-lobby/GameLobbyOptionsHub/GameLobbyOptionsHubFooter/__snapshots__/GameLobbyOptionsHubFooter.nuxt.spec.ts.snap
+++ b/tests/unit/specs/components/pages/game-lobby/GameLobbyOptionsHub/GameLobbyOptionsHubFooter/__snapshots__/GameLobbyOptionsHubFooter.nuxt.spec.ts.snap
@@ -1,0 +1,13 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Game Lobby Options Hub Footer Component > should match snapshot when rendered. 1`] = `
+"<div id="close-button-only-dialog-footer" class="w-full">
+  <divider-stub class="!my-2"></divider-stub>
+  <div class="flex justify-between w-full">
+    <transition-stub mode="out-in" name="fade" appear="false" persisted="false" css="true">
+      <div></div>
+    </transition-stub>
+    <button-stub id="close-button" label="Close" severity="secondary"></button-stub>
+  </div>
+</div>"
+`;

--- a/tests/unit/specs/components/shared/dialogs/DialogFooterCloseButtonOnly/DialogFooterCloseButtonOnly.nuxt.spec.ts
+++ b/tests/unit/specs/components/shared/dialogs/DialogFooterCloseButtonOnly/DialogFooterCloseButtonOnly.nuxt.spec.ts
@@ -24,13 +24,13 @@ describe("Dialog Footer Close Button Only Component", () => {
 
   describe("Close Button", () => {
     it("should translate close button when rendered.", () => {
-      const closeButton = wrapper.findComponent<typeof Button>("#close-button-only-dialog-footer-close-button");
+      const closeButton = wrapper.findComponent<typeof Button>("#only-dialog-footer-close-button");
 
       expect(closeButton.attributes("label")).toBe("Close");
     });
 
     it("should emit close event when close button is clicked.", async() => {
-      const closeButton = wrapper.findComponent<typeof Button>("#close-button-only-dialog-footer-close-button");
+      const closeButton = wrapper.findComponent<typeof Button>("#only-dialog-footer-close-button");
       await closeButton.trigger("click");
 
       expect(wrapper.emitted("closeDialog")).toBeTruthy();

--- a/tests/unit/specs/components/shared/dialogs/DialogFooterCloseButtonOnly/__snapshots__/DialogFooterCloseButtonOnly.nuxt.spec.ts.snap
+++ b/tests/unit/specs/components/shared/dialogs/DialogFooterCloseButtonOnly/__snapshots__/DialogFooterCloseButtonOnly.nuxt.spec.ts.snap
@@ -4,7 +4,7 @@ exports[`Dialog Footer Close Button Only Component > should match snapshot when 
 "<div id="close-button-only-dialog-footer" class="w-full">
   <divider-stub class="!my-2"></divider-stub>
   <div class="flex justify-end w-full">
-    <button-stub id="close-button-only-dialog-footer-close-button" label="Close" severity="secondary" size="small"></button-stub>
+    <button-stub id="only-dialog-footer-close-button" label="Close" severity="secondary" size="small"></button-stub>
   </div>
 </div>"
 `;

--- a/tests/unit/specs/stores/game/create-game-dto/useCreateGameDtoStore.spec.ts
+++ b/tests/unit/specs/stores/game/create-game-dto/useCreateGameDtoStore.spec.ts
@@ -4,11 +4,11 @@ import { createFakeCreateGamePlayerDto } from "@tests/unit/utils/factories/compo
 import { createFakeCreateGameDto } from "@tests/unit/utils/factories/composables/api/game/dto/create-game/create-game.dto.factory";
 import { createFakeGameOptions } from "@tests/unit/utils/factories/composables/api/game/game-options/game-options.factory";
 import { createFakeRole } from "@tests/unit/utils/factories/composables/api/role/role.factory";
+import type * as VueUse from "@vueuse/core";
 import { createPinia, setActivePinia } from "pinia";
 import { vi } from "vitest";
 import { DEFAULT_GAME_OPTIONS } from "~/composables/api/game/constants/game-options/game-options.constants";
 import type { CreateGameAdditionalCardDto } from "~/composables/api/game/dto/create-game/create-game-additional-card/create-game-additional-card.dto";
-import type * as VueUse from "@vueuse/core";
 
 import type { CreateGamePlayerDto } from "~/composables/api/game/dto/create-game/create-game-player/create-game-player.dto";
 import type { CreateGameDto } from "~/composables/api/game/dto/create-game/create-game.dto";
@@ -171,6 +171,26 @@ describe("Create Game Dto Store", () => {
         ],
       });
       createGameDtoStore.resetCreateGameDto(false);
+      const expectedGameOptions = createFakeGameOptions(DEFAULT_GAME_OPTIONS);
+
+      expect(createGameDtoStore.createGameOptionsDtoFromLocalStorage).toStrictEqual<{ value: GameOptions }>({ value: expectedGameOptions });
+    });
+  });
+
+  describe("resetCreateGameOptionsDto", () => {
+    it("should reset create game options dto with default values when called.", () => {
+      const createGameDtoStore = useCreateGameDtoStore();
+      createGameDtoStore.createGameDto.options = createFakeGameOptions();
+      createGameDtoStore.resetCreateGameOptionsDto();
+      const expectedGameOptions = createFakeGameOptions(DEFAULT_GAME_OPTIONS);
+
+      expect(createGameDtoStore.createGameDto.options).toStrictEqual<GameOptions>(expectedGameOptions);
+    });
+
+    it("should save create game options dto to local storage when called.", () => {
+      const createGameDtoStore = useCreateGameDtoStore();
+      createGameDtoStore.createGameDto.options = createFakeGameOptions();
+      createGameDtoStore.resetCreateGameOptionsDto();
       const expectedGameOptions = createFakeGameOptions(DEFAULT_GAME_OPTIONS);
 
       expect(createGameDtoStore.createGameOptionsDtoFromLocalStorage).toStrictEqual<{ value: GameOptions }>({ value: expectedGameOptions });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new footer component for the Game Lobby Options Hub, enhancing user interaction with reset and close functionalities.
	- Added localization support for new phrases in English and French related to game options.

- **Bug Fixes**
	- Improved the functionality of the reset button to accurately reflect changes in game options.

- **Tests**
	- Added unit tests for the new GameLobbyOptionsHubFooter component and its functionalities.
	- Enhanced test coverage for resetting game options in the store.

- **Chores**
	- Updated icon library to include the `faRotate` icon for additional UI options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->