### PR TITLE
feat(game-lobby): auto-focus on player name input even after changing page

### DIFF
--- a/app/components/pages/game-lobby/GameLobbyHeader/GameLobbyPlayerInput/GameLobbyPlayerInput.vue
+++ b/app/components/pages/game-lobby/GameLobbyHeader/GameLobbyPlayerInput/GameLobbyPlayerInput.vue
@@ -7,6 +7,7 @@
       <PrimeVueFloatLabel>
         <PrimeVueInputText
           id="player-name-input"
+          ref="playerNameInput"
           v-model="inputValue"
           aria-labelledby="player-name-input-help"
           :autofocus="!isOnTouchDevice"
@@ -52,7 +53,7 @@
 <script lang="ts" setup>
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { storeToRefs } from "pinia";
-import { computed } from "vue";
+import { type ComponentPublicInstance, computed } from "vue";
 
 import { MAX_PLAYERS_IN_GAME } from "~/composables/api/game/constants/game.constants";
 import { MAX_PLAYER_NAME_LENGTH } from "~/composables/api/game/constants/player/player.constants";
@@ -68,6 +69,8 @@ const { isOnTouchDevice } = useDevice();
 const { createGameDto } = storeToRefs(createGameDtoStore);
 
 const inputValue = defineModel<string>({ required: true });
+
+const playerNameInput = ref<ComponentPublicInstance | null>(null);
 
 const doesPlayerNameExistInGame = computed<boolean>(() => createGameDto.value.players.some(({ name }) => name === inputValue.value.trim()));
 
@@ -91,6 +94,17 @@ const playerNameInputHelpText = computed<string>(() => {
   }
   return t("components.GameLobbyPlayerInput.pleaseEnterPlayerName");
 });
+
+function focusOnPlayerNameInput(): void {
+  if (!playerNameInput.value) {
+    throw createError("Player name input is not defined");
+  }
+  if (!isOnTouchDevice.value) {
+    (playerNameInput.value.$el as HTMLElement).focus();
+  }
+}
+
+onMounted(focusOnPlayerNameInput);
 
 defineExpose({ isAddButtonDisabled });
 </script>

--- a/tests/unit/specs/components/pages/game-lobby/GameLobbyHeader/GameLobbyPlayerInput/GameLobbyPlayerInput.nuxt.spec.ts
+++ b/tests/unit/specs/components/pages/game-lobby/GameLobbyHeader/GameLobbyPlayerInput/GameLobbyPlayerInput.nuxt.spec.ts
@@ -1,12 +1,23 @@
+import { createFakeCreateGamePlayerDto } from "@tests/unit/utils/factories/composables/api/game/dto/create-game/create-game-player/create-game-player.dto.factory";
+import { getError } from "@tests/unit/utils/helpers/exception.helpers";
+import { mountSuspendedComponent } from "@tests/unit/utils/helpers/mount.helpers";
 import type { mount } from "@vue/test-utils";
 import type { ComponentMountingOptions } from "@vue/test-utils/dist/mount";
 import type InputText from "primevue/inputtext";
+import { expect } from "vitest";
+import type { Ref } from "vue";
 
 import type { GameLobbyPlayerInputProps } from "~/components/pages/game-lobby/GameLobbyHeader/GameLobbyPlayerInput/game-lobby-player-input.types";
 import GameLobbyPlayerInput from "~/components/pages/game-lobby/GameLobbyHeader/GameLobbyPlayerInput/GameLobbyPlayerInput.vue";
 import { useCreateGameDtoStore } from "~/stores/game/create-game-dto/useCreateGameDtoStore";
-import { createFakeCreateGamePlayerDto } from "@tests/unit/utils/factories/composables/api/game/dto/create-game/create-game-player/create-game-player.dto.factory";
-import { mountSuspendedComponent } from "@tests/unit/utils/helpers/mount.helpers";
+
+const hoistedMocks = vi.hoisted(() => ({
+  useDevice: { isOnTouchDevice: { value: false } },
+}));
+
+vi.mock("~/composables/misc/useDevice", () => ({
+  useDevice: (): typeof hoistedMocks.useDevice => hoistedMocks.useDevice,
+}));
 
 describe("Game Lobby Player Input Component", () => {
   let wrapper: ReturnType<typeof mount<typeof GameLobbyPlayerInput>>;
@@ -21,8 +32,17 @@ describe("Game Lobby Player Input Component", () => {
     },
   };
 
+  async function mountGameLobbyPlayerInputComponent(options: ComponentMountingOptions<typeof GameLobbyPlayerInput> = {}):
+  Promise<ReturnType<typeof mount<typeof GameLobbyPlayerInput>>> {
+    return mountSuspendedComponent(GameLobbyPlayerInput, {
+      ...defaultMountingOptions,
+      ...options,
+    });
+  }
+
   beforeEach(async() => {
-    wrapper = await mountSuspendedComponent(GameLobbyPlayerInput, defaultMountingOptions);
+    hoistedMocks.useDevice.isOnTouchDevice = ref(false);
+    wrapper = await mountGameLobbyPlayerInputComponent();
   });
 
   it("should match snapshot when rendered.", () => {
@@ -35,6 +55,31 @@ describe("Game Lobby Player Input Component", () => {
       const input = wrapper.findComponent<typeof InputText>("#player-name-input");
 
       expect(input.attributes("autofocus")).toBe("true");
+    });
+
+    it("should throw error when player name input is not defined in refs.", async() => {
+      (wrapper.vm.$root?.$refs.VTU_COMPONENT as { playerNameInput: Ref }).playerNameInput.value = null;
+      await getError(() => (wrapper.vm as unknown as { focusOnPlayerNameInput: () => void }).focusOnPlayerNameInput());
+
+      expect(createError).toHaveBeenCalledExactlyOnceWith("Player name input is not defined");
+    });
+
+    it("should call focus method on player name input when focusOnPlayerNameInput method is called and not on touch device.", () => {
+      const input = wrapper.findComponent<typeof InputText>("#player-name-input");
+      const focusSpy = vi.spyOn(input.element, "focus");
+      (wrapper.vm as unknown as { focusOnPlayerNameInput: () => void }).focusOnPlayerNameInput();
+
+      expect(focusSpy).toHaveBeenCalledExactlyOnceWith();
+    });
+
+    it("should not call focus method on player name input when focusOnPlayerNameInput method is called and on touch device.", async() => {
+      hoistedMocks.useDevice.isOnTouchDevice = ref(true);
+      wrapper = await mountGameLobbyPlayerInputComponent();
+      const input = wrapper.findComponent<typeof InputText>("#player-name-input");
+      const focusSpy = vi.spyOn(input.element, "focus");
+      (wrapper.vm as unknown as { focusOnPlayerNameInput: () => void }).focusOnPlayerNameInput();
+
+      expect(focusSpy).not.toHaveBeenCalled();
     });
 
     it("should be prefilled when v-model value is not empty.", async() => {
@@ -134,12 +179,12 @@ describe("Game Lobby Player Input Component", () => {
     });
 
     it("should translate button label when rendered.", async() => {
-      wrapper = await mountSuspendedComponent(GameLobbyPlayerInput, {
-        ...defaultMountingOptions,
+      wrapper = await mountGameLobbyPlayerInputComponent({
         global: {
           stubs: {
             InputGroup: false,
             Button: false,
+            FloatLabel: false,
           },
         },
       });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced automatic focus on the player name input field when the game lobby component is mounted, improving user experience.
  
- **Bug Fixes**
	- Enhanced error handling for scenarios where the player name input reference is not defined.

- **Tests**
	- Expanded test coverage for the player name input handling, ensuring robust functionality across different device types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->