### PR TITLE
feat(game-lobby): generation on server at demand

### DIFF
--- a/app/components/pages/game-lobby/GameLobbyHeader/GameLobbyHeaderSetupButtons/GameLobbyHeaderOptionsButton/GameLobbyHeaderOptionsButton.vue
+++ b/app/components/pages/game-lobby/GameLobbyHeader/GameLobbyHeaderSetupButtons/GameLobbyHeaderOptionsButton/GameLobbyHeaderOptionsButton.vue
@@ -17,14 +17,16 @@
       {{ $t("components.GameLobbyHeaderOptionsButton.gameOptions") }}
     </span>
 
-    <PrimeVueBadge
-      v-if="changedGameOptionsCount"
-      id="changed-game-options-count-badge"
-      v-p-tooltip="changedGameOptionsBadgeTooltip"
-      data-testid="changed-game-options-count-badge"
-      severity="secondary"
-      :value="changedGameOptionsCount"
-    />
+    <ClientOnly>
+      <PrimeVueBadge
+        v-if="changedGameOptionsCount"
+        id="changed-game-options-count-badge"
+        v-p-tooltip="changedGameOptionsBadgeTooltip"
+        data-testid="changed-game-options-count-badge"
+        severity="secondary"
+        :value="changedGameOptionsCount"
+      />
+    </ClientOnly>
   </PrimeVueButton>
 </template>
 

--- a/app/composables/misc/useDevice.ts
+++ b/app/composables/misc/useDevice.ts
@@ -5,7 +5,12 @@ type UseDevice = {
 };
 
 function useDevice(): UseDevice {
-  const isOnTouchDevice = computed<boolean>(() => "ontouchstart" in window || navigator.maxTouchPoints > 0);
+  const isOnTouchDevice = computed<boolean>(() => {
+    if (typeof window === "undefined") {
+      return false;
+    }
+    return "ontouchstart" in window || navigator.maxTouchPoints > 0;
+  });
 
   return {
     isOnTouchDevice,

--- a/app/pages/game-lobby.vue
+++ b/app/pages/game-lobby.vue
@@ -27,17 +27,19 @@
       @reject-thief-additional-cards-placed-step="onRejectThiefOrActorAdditionalCardsPlacedStep"
     />
 
-    <GameLobbyRolePicker ref="gameLobbyRolePicker"/>
+    <ClientOnly>
+      <GameLobbyRolePicker ref="gameLobbyRolePicker"/>
 
-    <GameLobbyOptionsHub ref="gameLobbyOptionsHub"/>
+      <GameLobbyOptionsHub ref="gameLobbyOptionsHub"/>
 
-    <GameLobbyPositionCoordinator ref="gameLobbyPositionCoordinator"/>
+      <GameLobbyPositionCoordinator ref="gameLobbyPositionCoordinator"/>
 
-    <GameLobbyAdditionalCardsManager ref="gameLobbyAdditionalCardsManager"/>
+      <GameLobbyAdditionalCardsManager ref="gameLobbyAdditionalCardsManager"/>
 
-    <GameLobbyGroupOrganizer ref="gameLobbyGroupOrganizer"/>
+      <GameLobbyGroupOrganizer ref="gameLobbyGroupOrganizer"/>
 
-    <GameLobbyBeforeLeaveConfirmDialog/>
+      <GameLobbyBeforeLeaveConfirmDialog/>
+    </ClientOnly>
   </div>
 </template>
 

--- a/app/stores/audio/useAudioStore.ts
+++ b/app/stores/audio/useAudioStore.ts
@@ -1,16 +1,16 @@
-import { useLocalStorage } from "@vueuse/core";
 import { Howl, Howler } from "howler";
+import { defineStore, storeToRefs } from "pinia";
 import { draw } from "radash";
-import { defineStore } from "pinia";
 
 import type { GamePhaseName } from "~/composables/api/game/types/game-phase/game-phase.types";
-import { BACKGROUND_AUDIO_NAMES, DEFAULT_AUDIO_SETTINGS, SOUND_EFFECT_NAMES } from "~/stores/audio/constants/audio.constants";
-import type { AudioSettings, BackgroundAudioName, SoundEffectName } from "~/stores/audio/types/audio.types";
+import { BACKGROUND_AUDIO_NAMES, SOUND_EFFECT_NAMES } from "~/stores/audio/constants/audio.constants";
+import type { BackgroundAudioName, SoundEffectName } from "~/stores/audio/types/audio.types";
 import { StoreIds } from "~/stores/enums/store.enum";
-import { LocalStorageKeys } from "~/utils/enums/local-storage.enums";
+import { useLocalStorageStore } from "~/stores/local-storage/useLocalStorageStore";
 
 const useAudioStore = defineStore(StoreIds.AUDIO, () => {
-  const audioSettingsFromLocalStorage = useLocalStorage<AudioSettings>(LocalStorageKeys.AUDIO_SETTINGS, DEFAULT_AUDIO_SETTINGS, { mergeDefaults: true });
+  const localStorageStore = useLocalStorageStore();
+  const { audioSettingsFromLocalStorage } = storeToRefs(localStorageStore);
 
   const isMuted = ref<boolean>(audioSettingsFromLocalStorage.value.isMuted);
 

--- a/app/stores/enums/store.enum.ts
+++ b/app/stores/enums/store.enum.ts
@@ -7,6 +7,7 @@ enum StoreIds {
   GAME_HISTORY_RECORDS = "gameHistoryRecords",
   GAME_EVENTS = "gameEvents",
   ROLES = "roles",
+  LOCAL_STORAGE = "localStorage",
 }
 
 export { StoreIds };

--- a/app/stores/game/create-game-dto/useCreateGameDtoStore.ts
+++ b/app/stores/game/create-game-dto/useCreateGameDtoStore.ts
@@ -1,13 +1,12 @@
-import { useLocalStorage } from "@vueuse/core";
-import { defineStore } from "pinia";
+import { defineStore, storeToRefs } from "pinia";
 import { get, set } from "radash";
 import type { Paths } from "type-fest";
 import { ref } from "vue";
 
 import { DEFAULT_GAME_OPTIONS } from "~/composables/api/game/constants/game-options/game-options.constants";
 import type { CreateGameAdditionalCardDto } from "~/composables/api/game/dto/create-game/create-game-additional-card/create-game-additional-card.dto";
-import { CreateGamePlayerDto } from "~/composables/api/game/dto/create-game/create-game-player/create-game-player.dto";
 import type { CreateGamePlayerWithGroupDto } from "~/composables/api/game/dto/create-game/create-game-player/create-game-player.dto";
+import { CreateGamePlayerDto } from "~/composables/api/game/dto/create-game/create-game-player/create-game-player.dto";
 import { CreateGameDto } from "~/composables/api/game/dto/create-game/create-game.dto";
 import type { GameAdditionalCardRecipientRoleName } from "~/composables/api/game/types/game-additional-card/game-additional-card.types";
 import { GameOptions } from "~/composables/api/game/types/game-options/game-options.class";
@@ -15,16 +14,17 @@ import type { DeepStringifiedGameOptions } from "~/composables/api/game/types/ga
 import { ADDITIONAL_CARDS_DEPENDANT_ROLES } from "~/composables/api/role/constants/role.constants";
 import type { RoleName } from "~/composables/api/role/types/role.types";
 import { StoreIds } from "~/stores/enums/store.enum";
+import { useLocalStorageStore } from "~/stores/local-storage/useLocalStorageStore";
 import { useRolesStore } from "~/stores/role/useRolesStore";
-import { LocalStorageKeys } from "~/utils/enums/local-storage.enums";
 
 const useCreateGameDtoStore = defineStore(StoreIds.CREATE_GAME_DTO, () => {
   const rolesStore = useRolesStore();
   const { getRoleWithNameInRoles } = rolesStore;
 
-  const { t } = useI18n();
+  const localStorageStore = useLocalStorageStore();
+  const { createGameOptionsDtoFromLocalStorage } = storeToRefs(localStorageStore);
 
-  const createGameOptionsDtoFromLocalStorage = useLocalStorage(LocalStorageKeys.GAME_OPTIONS, DEFAULT_GAME_OPTIONS, { mergeDefaults: true });
+  const { t } = useI18n();
 
   const defaultCreateGameDto = CreateGameDto.create({
     players: [],

--- a/app/stores/local-storage/useLocalStorageStore.ts
+++ b/app/stores/local-storage/useLocalStorageStore.ts
@@ -1,0 +1,25 @@
+import { useLocalStorage } from "@vueuse/core";
+import { defineStore, skipHydrate } from "pinia";
+
+import { DEFAULT_GAME_OPTIONS } from "~/composables/api/game/constants/game-options/game-options.constants";
+import { DEFAULT_AUDIO_SETTINGS } from "~/stores/audio/constants/audio.constants";
+import type { AudioSettings } from "~/stores/audio/types/audio.types";
+import { StoreIds } from "~/stores/enums/store.enum";
+import { LocalStorageKeys } from "~/utils/enums/local-storage.enums";
+
+const useLocalStorageStore = defineStore(StoreIds.LOCAL_STORAGE, () => {
+  const createGameOptionsDtoFromLocalStorage = useLocalStorage(LocalStorageKeys.GAME_OPTIONS, DEFAULT_GAME_OPTIONS, {
+    mergeDefaults: true,
+  });
+
+  const audioSettingsFromLocalStorage = useLocalStorage<AudioSettings>(LocalStorageKeys.AUDIO_SETTINGS, DEFAULT_AUDIO_SETTINGS, {
+    mergeDefaults: true,
+  });
+
+  return {
+    createGameOptionsDtoFromLocalStorage: skipHydrate(createGameOptionsDtoFromLocalStorage),
+    audioSettingsFromLocalStorage: skipHydrate(audioSettingsFromLocalStorage),
+  };
+});
+
+export { useLocalStorageStore };

--- a/config/eslint/flat-configs/eslint.global-config.mjs
+++ b/config/eslint/flat-configs/eslint.global-config.mjs
@@ -6,6 +6,7 @@ const ESLINT_GLOBAL_CONFIG = Object.freeze({
   name: "global",
   languageOptions: {
     globals: {
+      global: READONLY,
       window: READONLY,
       process: READONLY,
       navigator: READONLY,

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -74,7 +74,7 @@ export default defineNuxtConfig({
   devtools: { enabled: true },
   experimental: {
     renderJsonPayloads: false,
-    buildCache: true,
+    buildCache: false,
   },
   ogImage: {
     enabled: process.env.NODE_ENV !== "test",
@@ -223,7 +223,7 @@ export default defineNuxtConfig({
   routeRules: {
     "/": { prerender: true },
     "/about": { swr: true },
-    "/game-lobby": { ssr: false },
+    "/game-lobby": { swr: true },
     "/game": { ssr: false },
     "/game/**": { ssr: false },
   },

--- a/tests/acceptance/features/about/features/about.feature
+++ b/tests/acceptance/features/about/features/about.feature
@@ -60,9 +60,6 @@ Feature: ❓ About Page
     When the user hovers the link with name "I don't know this game"
     Then the tooltip with text "Watch an explanatory video on YouTube" should be visible
 
-    When the user clicks on the link with name "I don't know this game"
-    Then a new page should be opened with url starting with "https://www.youtube.com"
-
   Scenario: ❓ User goes on GitHub to contribute to the project by clicking on the link
     Given the user is on about page
     And the user is about to open a page on new tab

--- a/tests/acceptance/features/about/features/about.feature
+++ b/tests/acceptance/features/about/features/about.feature
@@ -60,6 +60,9 @@ Feature: ❓ About Page
     When the user hovers the link with name "I don't know this game"
     Then the tooltip with text "Watch an explanatory video on YouTube" should be visible
 
+    When the user clicks on the link with name "I don't know this game"
+    Then a new page should be opened with url starting with "https://www.youtube.com"
+
   Scenario: ❓ User goes on GitHub to contribute to the project by clicking on the link
     Given the user is on about page
     And the user is about to open a page on new tab

--- a/tests/unit/specs/components/pages/game-lobby/GameLobbyHeader/GameLobbyHeaderSetupButtons/GameLobbyHeaderOptionsButton/GameLobbyHeaderOptionsButton.nuxt.spec.ts
+++ b/tests/unit/specs/components/pages/game-lobby/GameLobbyHeader/GameLobbyHeaderSetupButtons/GameLobbyHeaderOptionsButton/GameLobbyHeaderOptionsButton.nuxt.spec.ts
@@ -29,6 +29,7 @@ describe("Game Lobby Header Options Button Component", () => {
         plugins: [createTestingPinia(testingPinia)],
         stubs: {
           Button: false,
+          ClientOnly: false,
         },
       },
       ...options,
@@ -90,6 +91,7 @@ describe("Game Lobby Header Options Button Component", () => {
           ],
           stubs: {
             Button: false,
+            ClientOnly: false,
           },
         },
       });

--- a/tests/unit/specs/composables/misc/useDevice.spec.ts
+++ b/tests/unit/specs/composables/misc/useDevice.spec.ts
@@ -10,10 +10,6 @@ describe("Use Device Composable", () => {
       delete window.ontouchstart;
     });
 
-    afterAll(() => {
-      delete window.ontouchstart;
-    });
-
     it("should return true when on touchstartevent is available on window object.", () => {
       window.ontouchstart = (): object => ({});
       const { isOnTouchDevice } = useDevice();
@@ -30,6 +26,17 @@ describe("Use Device Composable", () => {
     });
 
     it("should return false when neither 'ontouchstart' nor navigator.maxTouchPoints are available.", () => {
+      const { isOnTouchDevice } = useDevice();
+
+      expect(isOnTouchDevice.value).toBeFalsy();
+    });
+
+    it("should return false when window is undefined.", () => {
+      // eslint-disable-next-line no-underscore-dangle
+      (navigator as unknown as { __defineGetter__: (prop: string, getter: () => unknown) => void }).__defineGetter__("maxTouchPoints", () => 2);
+      Object.defineProperty(global, "window", {
+        value: undefined,
+      });
       const { isOnTouchDevice } = useDevice();
 
       expect(isOnTouchDevice.value).toBeFalsy();

--- a/tests/unit/specs/composables/misc/useDevice.spec.ts
+++ b/tests/unit/specs/composables/misc/useDevice.spec.ts
@@ -4,22 +4,27 @@ import { useDevice } from "~/composables/misc/useDevice";
 
 describe("Use Device Composable", () => {
   describe("isOnTouchDevice", () => {
+    const originalWindow = global.window;
+
     beforeEach(() => {
-      // eslint-disable-next-line no-underscore-dangle
-      (navigator as unknown as { __defineGetter__: (prop: string, getter: () => unknown) => void }).__defineGetter__("maxTouchPoints", () => 0);
-      delete window.ontouchstart;
+      vi.stubGlobal("navigator", { maxTouchPoints: 0 });
+      vi.stubGlobal("window", {});
+    });
+
+    afterEach(() => {
+      vi.stubGlobal("window", originalWindow);
+      vi.unstubAllGlobals();
     });
 
     it("should return true when on touchstartevent is available on window object.", () => {
-      window.ontouchstart = (): object => ({});
+      vi.stubGlobal("window", { ontouchstart: () => ({}) });
       const { isOnTouchDevice } = useDevice();
 
       expect(isOnTouchDevice.value).toBeTruthy();
     });
 
     it("should return true when navigator.maxTouchPoints is greater than 0.", () => {
-      // eslint-disable-next-line no-underscore-dangle
-      (navigator as unknown as { __defineGetter__: (prop: string, getter: () => unknown) => void }).__defineGetter__("maxTouchPoints", () => 2);
+      vi.stubGlobal("navigator", { maxTouchPoints: 2 });
       const { isOnTouchDevice } = useDevice();
 
       expect(isOnTouchDevice.value).toBeTruthy();
@@ -32,11 +37,9 @@ describe("Use Device Composable", () => {
     });
 
     it("should return false when window is undefined.", () => {
-      // eslint-disable-next-line no-underscore-dangle
-      (navigator as unknown as { __defineGetter__: (prop: string, getter: () => unknown) => void }).__defineGetter__("maxTouchPoints", () => 2);
-      Object.defineProperty(global, "window", {
-        value: undefined,
-      });
+      vi.stubGlobal("navigator", { maxTouchPoints: 2 });
+      vi.stubGlobal("window", undefined);
+
       const { isOnTouchDevice } = useDevice();
 
       expect(isOnTouchDevice.value).toBeFalsy();

--- a/tests/unit/specs/pages/game-lobby/game-lobby.nuxt.spec.ts
+++ b/tests/unit/specs/pages/game-lobby/game-lobby.nuxt.spec.ts
@@ -86,6 +86,7 @@ describe("Game Lobby Page", () => {
     return mountSuspendedComponent(GameLobby, {
       global: {
         stubs: {
+          ClientOnly: false,
           GameLobbyHeader: {
             template: "<div id='game-lobby-header-stub'></div>",
             methods: mocks.components.gameLobbyHeader,

--- a/tests/unit/specs/stores/audio/useAudioStore.spec.ts
+++ b/tests/unit/specs/stores/audio/useAudioStore.spec.ts
@@ -1,8 +1,7 @@
-import type * as VueUse from "@vueuse/core";
+import type Howler from "howler";
 import { createPinia, setActivePinia } from "pinia";
 import type Radash from "radash";
 import { vi } from "vitest";
-import type Howler from "howler";
 
 import { DEFAULT_AUDIO_SETTINGS } from "~/stores/audio/constants/audio.constants";
 import type { AudioSettings } from "~/stores/audio/types/audio.types";
@@ -21,7 +20,11 @@ const hoistedMocks = vi.hoisted(() => ({
       stop: vi.fn(),
     })),
   },
-  useLocalStorage: vi.fn(() => ({ value: DEFAULT_AUDIO_SETTINGS })),
+  useLocalStorageStore: vi.fn(() => ({
+    audioSettingsFromLocalStorage: {
+      value: {},
+    },
+  })),
 }));
 
 vi.mock("howler", async importOriginal => ({
@@ -32,14 +35,14 @@ vi.mock("radash", async importOriginal => ({
   ...await importOriginal<typeof Radash>(),
   ...hoistedMocks.radash,
 }));
-vi.mock("@vueuse/core", async importOriginal => ({
-  ...await importOriginal<typeof VueUse>(),
-  useLocalStorage: hoistedMocks.useLocalStorage,
+vi.mock("~/stores/local-storage/useLocalStorageStore.ts", () => ({
+  useLocalStorageStore: hoistedMocks.useLocalStorageStore,
 }));
 
 describe("Use Audio Store", () => {
   beforeEach(() => {
     setActivePinia(createPinia());
+    hoistedMocks.useLocalStorageStore.mockReturnValue({ audioSettingsFromLocalStorage: ref(DEFAULT_AUDIO_SETTINGS) });
   });
 
   describe("Initial State", () => {
@@ -65,12 +68,6 @@ describe("Use Audio Store", () => {
         src: [`/audio/audio-backgrounds/night-3.webm`],
         loop: true,
       });
-    });
-
-    it("should set audio settings from local storage when created.", () => {
-      useAudioStore();
-
-      expect(hoistedMocks.useLocalStorage).toHaveBeenCalledExactlyOnceWith("audioSettings", DEFAULT_AUDIO_SETTINGS, { mergeDefaults: true });
     });
 
     it("should set playing background audio name to undefined when created.", () => {
@@ -290,7 +287,7 @@ describe("Use Audio Store", () => {
       const { setMute } = audioStore;
       setMute(true);
 
-      expect(audioStore.audioSettingsFromLocalStorage).toStrictEqual<{ value: AudioSettings }>({ value: { isMuted: true } });
+      expect(audioStore.audioSettingsFromLocalStorage).toStrictEqual<AudioSettings>({ isMuted: true });
     });
   });
 

--- a/tests/unit/specs/stores/game/create-game-dto/useCreateGameDtoStore.spec.ts
+++ b/tests/unit/specs/stores/game/create-game-dto/useCreateGameDtoStore.spec.ts
@@ -1,4 +1,3 @@
-import type * as VueUse from "@vueuse/core";
 import { createPinia, setActivePinia } from "pinia";
 import { vi } from "vitest";
 
@@ -17,27 +16,25 @@ import type { RoleName } from "~/composables/api/role/types/role.types";
 import { useCreateGameDtoStore } from "~/stores/game/create-game-dto/useCreateGameDtoStore";
 import { useRolesStore } from "~/stores/role/useRolesStore";
 
-const hoistedMocks = vi.hoisted(() => ({ useLocalStorage: vi.fn(() => ({ value: DEFAULT_GAME_OPTIONS })) }));
+const hoistedMocks = vi.hoisted(() => ({
+  useLocalStorageStore: vi.fn(() => ({
+    createGameOptionsDtoFromLocalStorage: {
+      value: DEFAULT_GAME_OPTIONS,
+    },
+  })),
+}));
 
-vi.mock("@vueuse/core", async importOriginal => ({
-  ...await importOriginal<typeof VueUse>(),
-  useLocalStorage: hoistedMocks.useLocalStorage,
+vi.mock("~/stores/local-storage/useLocalStorageStore.ts", () => ({
+  useLocalStorageStore: hoistedMocks.useLocalStorageStore,
 }));
 
 describe("Create Game Dto Store", () => {
   beforeEach(() => {
     setActivePinia(createPinia());
-    hoistedMocks.useLocalStorage.mockReturnValue({ value: DEFAULT_GAME_OPTIONS });
-  });
-
-  it("should retrieve game options from local storage when created.", () => {
-    useCreateGameDtoStore();
-
-    expect(hoistedMocks.useLocalStorage).toHaveBeenCalledExactlyOnceWith("gameOptions", DEFAULT_GAME_OPTIONS, { mergeDefaults: true });
+    hoistedMocks.useLocalStorageStore.mockReturnValue({ createGameOptionsDtoFromLocalStorage: ref(DEFAULT_GAME_OPTIONS) });
   });
 
   it("should have initial state with game options from local storage when created.", () => {
-    hoistedMocks.useLocalStorage.mockReturnValue({ value: DEFAULT_GAME_OPTIONS });
     const createGameDtoStore = useCreateGameDtoStore();
     const expectedCreateGameDto = createFakeCreateGameDto({ options: DEFAULT_GAME_OPTIONS });
 
@@ -128,7 +125,7 @@ describe("Create Game Dto Store", () => {
       });
       createGameDtoStore.setCreateGameDto(expectedCreateGameDto);
 
-      expect(createGameDtoStore.createGameOptionsDtoFromLocalStorage).toStrictEqual<{ value: GameOptions }>({ value: expectedCreateGameDto.options });
+      expect(createGameDtoStore.createGameOptionsDtoFromLocalStorage).toStrictEqual<GameOptions>(expectedCreateGameDto.options);
     });
   });
 
@@ -249,7 +246,7 @@ describe("Create Game Dto Store", () => {
 
     it("should reset create game dto with local storage values when local storage values are kept.", () => {
       const randomGameOptions = createFakeGameOptions();
-      hoistedMocks.useLocalStorage.mockReturnValue({ value: randomGameOptions });
+      hoistedMocks.useLocalStorageStore.mockReturnValue({ createGameOptionsDtoFromLocalStorage: ref(randomGameOptions) });
       const createGameDtoStore = useCreateGameDtoStore();
       createGameDtoStore.createGameDto = createFakeCreateGameDto({
         players: [
@@ -269,7 +266,7 @@ describe("Create Game Dto Store", () => {
 
     it("should not save create game options dto to local storage when local storage values are not kept.", () => {
       const randomGameOptions = createFakeGameOptions();
-      hoistedMocks.useLocalStorage.mockReturnValue({ value: randomGameOptions });
+      hoistedMocks.useLocalStorageStore.mockReturnValue({ createGameOptionsDtoFromLocalStorage: ref(randomGameOptions) });
       const createGameDtoStore = useCreateGameDtoStore();
       createGameDtoStore.createGameDto = createFakeCreateGameDto({
         players: [
@@ -281,7 +278,7 @@ describe("Create Game Dto Store", () => {
       createGameDtoStore.resetCreateGameDto(false);
       const expectedGameOptions = createFakeGameOptions(DEFAULT_GAME_OPTIONS);
 
-      expect(createGameDtoStore.createGameOptionsDtoFromLocalStorage).toStrictEqual<{ value: GameOptions }>({ value: expectedGameOptions });
+      expect(createGameDtoStore.createGameOptionsDtoFromLocalStorage).toStrictEqual<GameOptions>(expectedGameOptions);
     });
   });
 
@@ -301,7 +298,7 @@ describe("Create Game Dto Store", () => {
       createGameDtoStore.resetCreateGameOptionsDto();
       const expectedGameOptions = createFakeGameOptions(DEFAULT_GAME_OPTIONS);
 
-      expect(createGameDtoStore.createGameOptionsDtoFromLocalStorage).toStrictEqual<{ value: GameOptions }>({ value: expectedGameOptions });
+      expect(createGameDtoStore.createGameOptionsDtoFromLocalStorage).toStrictEqual<GameOptions>(expectedGameOptions);
     });
   });
 
@@ -324,7 +321,7 @@ describe("Create Game Dto Store", () => {
       createGameDtoStore.createGameDto.options = randomGameOptions;
       createGameDtoStore.saveCreateGameOptionsDtoToLocalStorage();
 
-      expect(createGameDtoStore.createGameOptionsDtoFromLocalStorage).toStrictEqual<{ value: GameOptions }>({ value: randomGameOptions });
+      expect(createGameDtoStore.createGameOptionsDtoFromLocalStorage).toStrictEqual<GameOptions>(randomGameOptions);
     });
   });
 

--- a/tests/unit/specs/stores/local-storage/useLocalStorageStore.nuxt.spec.ts
+++ b/tests/unit/specs/stores/local-storage/useLocalStorageStore.nuxt.spec.ts
@@ -1,0 +1,34 @@
+import { createPinia, setActivePinia } from "pinia";
+import { vi } from "vitest";
+import type * as VueUse from "@vueuse/core";
+
+import { DEFAULT_GAME_OPTIONS } from "~/composables/api/game/constants/game-options/game-options.constants";
+import { useLocalStorageStore } from "~/stores/local-storage/useLocalStorageStore";
+import { LocalStorageKeys } from "~/utils/enums/local-storage.enums";
+
+const hoistedMocks = vi.hoisted(() => ({
+  useLocalStorage: vi.fn(() => ({})),
+}));
+
+vi.mock("@vueuse/core", async importOriginal => ({
+  ...await importOriginal<typeof VueUse>(),
+  useLocalStorage: hoistedMocks.useLocalStorage,
+}));
+
+describe("Use Local Storage Store", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it("should call useLocalStorage with for stored game options when created.", () => {
+    useLocalStorageStore();
+
+    expect(hoistedMocks.useLocalStorage).toHaveBeenCalledWith(LocalStorageKeys.GAME_OPTIONS, DEFAULT_GAME_OPTIONS, { mergeDefaults: true });
+  });
+
+  it("should call useLocalStorage with for stored audio settings when created.", () => {
+    useLocalStorageStore();
+
+    expect(hoistedMocks.useLocalStorage).toHaveBeenCalledWith(LocalStorageKeys.AUDIO_SETTINGS, expect.any(Object), { mergeDefaults: true });
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a `ClientOnly` wrapper for several components in the Game Lobby, ensuring they are rendered only on the client side.
	- Added a new local storage management system for game options and audio settings.

- **Bug Fixes**
	- Enhanced logic in the `useDevice` function to prevent errors in environments without a `window` object.

- **Tests**
	- Updated test suite for the Game Lobby page to include the `ClientOnly` component, improving test coverage and validation of page behavior.
	- Revised tests for audio and game creation stores to reflect changes in local storage handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->