### PR TITLE
ci(runner): runs large tasks on ovh instance

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -261,7 +261,7 @@ jobs:
 
   mutant-tests:
     name: Mutant Tests 👽
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     env:
       STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
       VERSION: ${{ github.head_ref }}

--- a/config/stryker/stryker-ci.conf.mjs
+++ b/config/stryker/stryker-ci.conf.mjs
@@ -23,7 +23,6 @@ if (process.env.VERSION !== undefined) {
 
 export default {
   ...defaultConfig,
-  concurrency: 1,
   reporters,
   dashboard,
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the configuration for the `mutant-tests` job to run on a self-hosted environment.
	- Added environment variables for dashboard API key and versioning in the test configuration.
	- Adjusted reporting settings for test results, enhancing output formats and conditional dashboard integration.
	- Removed concurrency settings from the test configuration, impacting execution handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->